### PR TITLE
feat(iris): support single line macros

### DIFF
--- a/iris/build.c
+++ b/iris/build.c
@@ -278,14 +278,16 @@ static int __build_test(char debug)
         return 0;
 }
 
-#define __FIXTURES_N 1
+#define __FIXTURES_N 2
 
 static const char *fixturepaths[__FIXTURES_N] = {
 	"./test/00-fib.c ",
+	"./test/01-helloworld.c ",
 };
 
 static const char *fixture_outputs[__FIXTURES_N] = {
 	"./dist/00-fib ",
+	"./dist/01-helloworld ",
 };
 
 static int __build_test_fixtures(char debug)

--- a/iris/src/iris.c
+++ b/iris/src/iris.c
@@ -97,7 +97,6 @@ int lexer_next_token(lexer_t *l, token_t *t)
 
 	state_t state = STATE_INITIAL;
 
-
 	size_t start = l->pos;
 	size_t colstart = l->col;
 
@@ -264,6 +263,14 @@ int lexer_next_token(lexer_t *l, token_t *t)
 					{
 
 						__lexer_advance(l, curr);
+					}; break;
+
+					case '#':
+					{
+						while (curr != '\n' && l->pos < l->data_len)
+						{
+							curr = __lexer_advance(l, curr);
+						}
 					}; break;
 
 					default:

--- a/iris/test/01-helloworld.c
+++ b/iris/test/01-helloworld.c
@@ -1,0 +1,83 @@
+#include <stdio.h>
+
+#include "lib.h"
+#include "../lib/iris.h"
+
+int main(void)
+{
+	START_CASE("01-helloworld.c")
+
+	io_string_t str = {0};
+
+	int err = file_into_memory("./test/examples/01-helloworld.c", &str);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to load file into memory");	
+
+	lexer_t l = {0};
+	err = lexer_init(&l, str.buff, str.len);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to initialize lexer into memory");	
+
+	token_t t = {0};
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 20, 23, 2, 1, TOKEN_TYPE_INT, t);
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 24, 28, 2, 4, TOKEN_TYPE_IDENTIFIER, t);
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 28, 28, 2, 9, TOKEN_TYPE_LEFT_PAREN, t);
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 29, 33, 2, 10, TOKEN_TYPE_VOID, t);
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 33, 33, 2, 14, TOKEN_TYPE_RIGHT_PAREN, t);
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 34, 35, 3, 1, TOKEN_TYPE_LEFT_BRACE, t);
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 38, 44, 4, 2, TOKEN_TYPE_IDENTIFIER, t);
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 44, 44, 4, 11, TOKEN_TYPE_LEFT_PAREN, t);
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 45, 62, 4, 12, TOKEN_TYPE_STRING_LITERAL, t);
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 62, 62, 4, 29, TOKEN_TYPE_RIGHT_PAREN, t);
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 63, 63, 4, 30, TOKEN_TYPE_SEMICOLON, t);
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 66, 72, 5, 31, TOKEN_TYPE_RETURN, t);
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 73, 74, 5, 11, TOKEN_TYPE_NUMERIC_LITERAL, t);
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 74, 74, 5, 13, TOKEN_TYPE_SEMICOLON, t);
+
+	err = lexer_next_token(&l, &t);
+	ASSERT_EQ(0, err, "01-helloworld.c", "should not fail to lex valid program");	
+	ASSERT_TOKEN_EQ("01-helloworld.c", 75, 76, 6, 1, TOKEN_TYPE_RIGHT_BRACE, t);
+
+	SUCCESS("01-helloworld.c")
+}
+

--- a/iris/test/examples/01-helloworld.c
+++ b/iris/test/examples/01-helloworld.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+
+int main(void)
+{
+	printf("Hello, world!\n");
+	return 0;
+}


### PR DESCRIPTION
Since we should have handled macros long before the lexer actually comes into place we simply skip macro lines all the way until we find something that is lexable